### PR TITLE
nginx: increase nginx body size

### DIFF
--- a/files/all/etc/nginx/uci.conf.template
+++ b/files/all/etc/nginx/uci.conf.template
@@ -18,7 +18,7 @@ http {
 	default_type application/octet-stream;
 	sendfile on;
 
-	client_max_body_size 32k;
+	client_max_body_size 256M;
 	large_client_header_buffers 4 32k;
 
 	gzip on;


### PR DESCRIPTION
fix: daemon.err nginx[8751]: 2024/04/08 22:17:52 [error] 8759#0: *9 client intended to send too large body: 191975675 bytes